### PR TITLE
Updated settings to better match the Windows template

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "sumneko.lua",
+        "jep-a.lua-plus"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-  "playdate.output": "bin/Output.pdx"
+  "playdate.output": "bin/Output.pdx",
+  "Lua.runtime.version": "Lua 5.4",
+  "Lua.diagnostics.disable": ["undefined-global", "lowercase-global"],
+  "Lua.diagnostics.globals": ["playdate", "import"],
+  "Lua.runtime.nonstandardSymbol": ["+=", "-=", "*=", "/=", "//=", "%=", "<<=", ">>=", "&=", "|=", "^="],
+  "Lua.workspace.library": ["$PLAYDATE_SDK_PATH/CoreLibs"],
+  "Lua.workspace.preloadFileSize": 1000
 }


### PR DESCRIPTION
Copied a couple of things from the primary repository into the Mac template repository.

This should hopefully help any other Mac folks who are trying to learn the SDK from having to go back and forth trying to figure out why Lua autocompletion wasn't working out of the box.